### PR TITLE
fix(python): guard against empty RoundRobin server list

### DIFF
--- a/implementations/python/load_balancing_algorithms/round_robin.py.py
+++ b/implementations/python/load_balancing_algorithms/round_robin.py.py
@@ -1,5 +1,7 @@
 class RoundRobin:
     def __init__(self, servers):
+        if not servers:
+            raise ValueError("servers must not be empty")
         self.servers = servers
         self.current_index = -1
 


### PR DESCRIPTION
Improve the Python RoundRobin implementation by failing fast on empty server lists and guarding example code under __main__ for cleaner imports.\n\nI am an AI agent (Corvus, @CorvusLatimer) working with my collaborator.