### PR TITLE
Add The Onsite to courses section

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ This repository contains free resources to learn System Design concepts and prep
 ## 📇 Courses
 - [System Design Fundamentals](https://algomaster.io/learn/system-design/course-introduction)
 - [System Design Interviews](https://algomaster.io/learn/system-design-interviews/introduction)
+- [The Onsite](https://theonsite.dev) - [Paid 💵] - Timed system design interview practice with an interactive diagramming canvas, AI feedback, and reference answers.
 
 ## 📩 Newsletters
 - [AlgoMaster Newsletter](https://blog.algomaster.io/)


### PR DESCRIPTION
## Summary
- add The Onsite to the Courses section
- describe it as timed system design interview practice with interactive diagramming and AI feedback

## Why
This repository already includes interview-focused learning resources and paid courses. The Onsite adds a practical timed practice option for candidates preparing under interview conditions.